### PR TITLE
fix wrong error message

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -79,7 +79,7 @@ vagrant_uid=$($ssh id -u vagrant 2>/dev/null)
 
 set -e
 
-if [ "$vagrant_uid" == "1000" ] || ([ "$exists" != "" ] && [ "$exists" != "1000" ]); then
+if [ "$vagrant_uid" == "1000" ] && ([ "$exists" != "" ] && [ "$exists" != "1000" ]); then
   echo switching is required, remove $username and try again
 fi
 if [ -z "$vagrant_uid" ]; then


### PR DESCRIPTION
After changing ssh port in `ssh.config`

It didn't recover by running bootstrap.sh

```
switching is required, remove myusername and try again
root@127.0.0.1: Permission denied (publickey,password).
```

the error is supposed to be just 

```
root@127.0.0.1: Permission denied (publickey,password).
```


